### PR TITLE
Changed streamroot key to optional in DNAConfig

### DIFF
--- a/AVPlayerDNAPlugin.podspec
+++ b/AVPlayerDNAPlugin.podspec
@@ -1,18 +1,18 @@
 Pod::Spec.new do |s|  
     s.name              = 'AVPlayerDNAPlugin'
-    s.version           = '1.1.11'
+    s.version           = '1.1.12'
     s.swift_version     = '5.0'
     s.summary           = 'Streamroot Distributed Network Architecture AVPlayer plugins, a new way to deliver large-scale OTT video'
     s.homepage          = 'https://www.streamroot.io/'
     s.author            = { 'Name' => 'support-team@streamroot.io' }
     s.license      = {
         :type => 'Copyright',
-        :text => 'Copyright 2018 Streamroot. See the terms of service at https://www.streamroot.io/'
+        :text => 'Copyright 2019 Streamroot. See the terms of service at https://www.streamroot.io/'
     }
     s.platform          = :ios
     s.source            ={ :git => 'https://github.com/streamroot/avplayer-dna-plugin.git',  :tag => "#{s.version}"}
     s.source_files = 'PlayerDNAPlugin/Classes/*.swift'
     s.ios.deployment_target = '10.2'
     s.tvos.deployment_target = '10.2'
-    s.dependency 'StreamrootSDK', '~> 3.15.0'
+    s.dependency 'StreamrootSDK', '~> 3.15.1'
 end

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-binary "https://sdk.streamroot.io/ios/StreamrootSDK.json" ~> 3.15.0
+binary "https://sdk.streamroot.io/ios/StreamrootSDK.json" ~> 3.15.1
 github "apple/swift-protobuf" "1.6.0"
 github "daltoniam/Starscream" "3.1.0"
 github "getsentry/sentry-cocoa" "4.4.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "https://sdk.streamroot.io/ios/StreamrootSDK.json" "3.15.0"
+binary "https://sdk.streamroot.io/ios/StreamrootSDK.json" "3.15.1"
 github "apple/swift-protobuf" "1.6.0"
 github "daltoniam/Starscream" "3.1.0"
 github "getsentry/sentry-cocoa" "4.4.0"

--- a/PlayerDNAPlugin/Classes/AVPlayerPlugin.swift
+++ b/PlayerDNAPlugin/Classes/AVPlayerPlugin.swift
@@ -25,10 +25,6 @@ import StreamrootSDK
 
     fileprivate var playbackState: PlaybackState
 
-    private var key: String {
-        return config.streamrootKey
-    }
-
     private var latency: Int {
         return config.latency ?? 0
     }
@@ -49,8 +45,8 @@ import StreamrootSDK
     /// - returns: Local manifest URL
     public func start() throws -> URL? {
         var builder = DNAClient.builder().dnaClientDelegate(self)
-        if !key.isEmpty {
-            builder = builder.streamrootKey(key)
+        if let srkey = config.streamrootKey, !srkey.isEmpty {
+            builder = builder.streamrootKey(srkey)
         }
 
         if let latency = config.latency, latency > 0 {

--- a/PlayerDNAPlugin/Classes/StreamrootPlugin.swift
+++ b/PlayerDNAPlugin/Classes/StreamrootPlugin.swift
@@ -13,7 +13,7 @@ import StreamrootSDK
     /// Unique Streamroot Key that we assigned to you,
     /// make sure it's identical to the one provided in the Account section of your dashboard
     // Can be set in the Plist or int the DNAConfig
-    public var streamrootKey: String
+    public var streamrootKey: String?
 
     /// Identifier used by the Streamroot backend to match peers who watch the same content.
     public var contentId: String?
@@ -25,7 +25,7 @@ import StreamrootSDK
     /// Used to change the place of the Streamroot backend. You must mention the protocol used, either "HTTP" or "HTTPS".
     public var backendHost: URL?
 
-    public init(streamrootKey: String,
+    public init(streamrootKey: String? = nil,
                 contentId: String? = nil,
                 latency: Int = 0,
                 property: String? = nil,


### PR DESCRIPTION
AVPlayerPlugin was forcing the developer to give a streamrootKey when configuring it. To default to the SRKey in the info.plist, the developer had to give an empty string as streamrootKey param to the config which is not intuitive when you need to autoload.
Now when SRKey is absent, nil, or empty from in the DNAConfig builder -> the SDK will correctly load the info.plist SRKey by default.
SDK requirement has been moved up to 3.15.1 minimum.